### PR TITLE
Update internal game version to v0.8.11

### DIFF
--- a/luckyapi/modloader/modloader.gd
+++ b/luckyapi/modloader/modloader.gd
@@ -5,7 +5,7 @@ const ModSymbol = preload("res://modloader/ModSymbol.gd")
 const SymbolPatcher = preload("res://modloader/SymbolPatcher.gd")
 
 const modloader_version := "v0.2.0"
-const expected_versions := ["v0.8.10"]
+const expected_versions := ["v0.8.11"]
 var game_version: String = "<game version not determined yet>"
 
 var exe_dir := OS.get_executable_path().get_base_dir()


### PR DESCRIPTION
The modloader works with the latest patch of Luck be a Landlord, but has not been updated to acknowledge the patch, resulting in a crash unless the file is modified on the client.