### PR TITLE
Add a Post Initialize Method

### DIFF
--- a/luckyapi/modloader/modloader.gd
+++ b/luckyapi/modloader/modloader.gd
@@ -279,6 +279,10 @@ func after_start():
     print("LuckyAPI MODLOADER > Initialization complete!")
 
     datadump()
+    for mod_id in mod_load_order:
+        var mod := mods[mod_id]
+        if mod.has_method("on_post_initialize"):
+            mod.on_post_initialize(self, tree)
 
 func load_mods():
     print("LuckyAPI MODLOADER > Loading mods...")


### PR DESCRIPTION
Basically just an optional hook that goes off after all mods/main is loaded in. Makes it much easier to add custom nodes so that they don't get overlapped by anything eg:
```gdscript
func on_post_initialize(loader, tree):
    tree.get_root().add_child(label)
```
![](https://cdn.discordapp.com/attachments/258041703276085250/864649536031031306/unknown.png)
