### PR TITLE
Content Patch #11 QoL additions, bug fixes and clickable symbols

### DIFF
--- a/luckyapi/modloader/modloader.gd
+++ b/luckyapi/modloader/modloader.gd
@@ -129,8 +129,6 @@ func patch_symbol(symbol_patch, id):
     var groups := database_entry.groups
     for group in groups:
         databases.group_database.symbols[group].erase(id)
-        if databases.group_database.symbols[group].size() == 0:
-            databases.group_database.symbols[group] = null
     
     groups = symbol_patch.patch_groups(groups)
     for group in groups:
@@ -154,13 +152,15 @@ func patch_symbol(symbol_patch, id):
         for extra_texture_key in extra_textures.keys():
             databases.icon_texture_database[id + "_" + extra_texture_key] = extra_textures[extra_texture_key]
     
-    var sfx := databases.sfx_database.symbols[id]
+    var sfx : Array = nvl(databases.sfx_database.symbols[id], [])
     if mod_symbol != null:
         sfx = symbol_patch.patch_sfx(mod_symbol.sfx)
         mod_symbol.sfx = sfx
     else:
         sfx = symbol_patch.patch_sfx(sfx)
     databases.sfx_database.symbols[id] = sfx
+    if sfx:
+        database_entry.sfx = sfx
     
     var sfx_overrides : Dictionary
     if mod_symbol != null:

--- a/luckyapi/modloader/patches/Main.gd
+++ b/luckyapi/modloader/patches/Main.gd
@@ -22,6 +22,8 @@ func load_globals(modloader: Reference):
     modloader.globals.items = $"/root/Main/Items"
     modloader.globals.reels = $"/root/Main/Reels"
     modloader.globals.pop_up = $"/root/Main/Pop-up Sprite/Pop-up"
+    modloader.globals.options = $"/root/Main/Options Sprite/Options"
+    modloader.globals.stats = $"/root/Main/Stats Sprite/Stats"
 
 func reset_values():
     .reset_values()

--- a/luckyapi/modloader/patches/Pop-up.gd
+++ b/luckyapi/modloader/patches/Pop-up.gd
@@ -16,16 +16,16 @@ func add_cards(f_rarities):
         var r_chances
         if email.type == "add_tile":
             if email.extra_values.has("forced_group"):
-                card_pool = $"/root/Main/".rarity_database["symbols"].duplicate(true)
+                card_pool = modloader.databases.rarity_database["symbols"].duplicate(true)
                 for c in card_pool.keys():
                     var c_tbe = []
                     for i in card_pool[c]:
-                        if $"/root/Main/".group_database["symbols"][email.extra_values.forced_group].find(i) == -1:
+                        if modloader.databases.group_database["symbols"][email.extra_values.forced_group].find(i) == -1:
                             c_tbe.push_back(i)
                     for z in c_tbe:
                         card_pool[c].erase(z)
             else:
-                card_pool = $"/root/Main/".rarity_database["symbols"].duplicate(true)
+                card_pool = modloader.databases.rarity_database["symbols"].duplicate(true)
                 if not reels.can_add_highlander():
                     card_pool["very_rare"].erase("highlander")
             for c in card_pool.keys():
@@ -33,22 +33,22 @@ func add_cards(f_rarities):
                     if not option_is_findable(i):
                         card_pool[c].erase(i)
             
-            r_chances = $"/root/Main/".rarity_chances["symbols"].duplicate(true)
-            database = $"/root/Main/".tile_database
+            r_chances = modloader.globals.main.rarity_chances["symbols"].duplicate(true)
+            database = modloader.databases.tile_database
             for r in r_chances.keys():
                 r_chances[r] *= rarity_bonuses["symbols"][r]
-            if not $"/root/Main/Stats Sprite/Stats".essences_unlocked:
+            if not modloader.globals.stats.essences_unlocked:
                 card_pool[database["essence_capsule"].rarity].erase("essence_capsule")
         elif email.type == "add_item":
             symbols_to_choose_from = 3
-            database = $"/root/Main/".item_database
-            card_pool = $"/root/Main/".rarity_database["items"].duplicate(true)
-            for i in $"/root/Main/Items".items:
+            database = modloader.databases.item_database
+            card_pool = modloader.databases.rarity_database["items"].duplicate(true)
+            for i in modloader.globals.items.items:
                 card_pool[i.rarity].erase(i.type)
-            for i in $"/root/Main/Items".destroyed_items:
+            for i in modloader.globals.items.destroyed_items:
                 if database[i].rarity != "essence":
                     card_pool[database[i].rarity].erase(i)
-            r_chances = $"/root/Main/".rarity_chances["items"].duplicate(true)
+            r_chances = modloader.globals.main.rarity_chances["items"].duplicate(true)
             for r in r_chances.keys():
                 r_chances[r] *= rarity_bonuses["items"][r]
             if email.extra_values.hash() != {"forced_rarity": ["essence", "essence", "essence"]}.hash():
@@ -62,7 +62,7 @@ func add_cards(f_rarities):
                     for i in range(comfy_pillow_essence_triggers):
                         email.extra_values.forced_rarity.push_back("very_rare")
                     comfy_pillow_essence_triggers = 0
-            if not $"/root/Main/Stats Sprite/Stats".essences_unlocked:
+            if not modloader.globals.stats.essences_unlocked:
                 card_pool[database["dishwasher"].rarity].erase("dishwasher")
                 card_pool[database["popsicle"].rarity].erase("popsicle")
         for c in range(symbols_to_choose_from):
@@ -136,7 +136,7 @@ func add_cards(f_rarities):
             else:
                 card.data = database[saved_card_types[c]]
                 cards.push_back(card)
-        $"/root/Main".save_game()
+        modloader.globals.main.save_game()
         var total_card_width = 0
         var tallest_height = 0
         for c in cards:

--- a/luckyapi/modloader/patches/SlotIcon.gd
+++ b/luckyapi/modloader/patches/SlotIcon.gd
@@ -18,6 +18,13 @@ func _ready():
     ._ready()
     update_mod_symbol(self.type)
 
+func _input(event):
+    if hovering and event is InputEventMouseButton and event.is_pressed() and event.button_index == BUTTON_LEFT and not modloader.globals.main.lmb_down:
+        if modloader.globals.pop_up.emails.size() == 0:
+            if mod_symbol and mod_symbol.has_method("on_click"):
+                mod_symbol.on_click(self, mod_symbol)
+    ._input(event)
+
 func change_type(p_type: String, need_cond_effects: bool):
     update_mod_symbol(p_type)
     .change_type(p_type, need_cond_effects)
@@ -46,7 +53,7 @@ func start_animation(anim):
             set_texture(texture)
 
 func play_sfx(symbol, sfx_type):
-    if $"/root/Main/Options Sprite/Options".animation_speed == 0 and reels.sfx_timer > 0:
+    if modloader.globals.options.animation_speed == 0 and reels.sfx_timer > 0:
         delayed_sfx.push_back([symbol, sfx_type])
         return
     var player = symbol.sfx_player
@@ -112,8 +119,8 @@ func play_sfx(symbol, sfx_type):
         else:
             player.stream.loop_begin = 0
             player.stream.loop_end = 0
-        player.volume_db = $"/root/Main/Options Sprite/Options".sfx.goal_volume
-        if player.volume_db > -80 and not ($"/root/Main/Options Sprite/Options".mute_while_in_background and not $"/root/Main".window_focus):
+        player.volume_db = modloader.globals.options.sfx.goal_volume
+        if player.volume_db > -80 and not (modloader.globals.options.mute_while_in_background and not modloader.globals.main.window_focus):
             player.play()
             reels.sfx_timer = 1
 
@@ -204,14 +211,16 @@ func add_conditional_effects():
         mod_symbol.add_conditional_effects(self, adj_icons)
         add_effect({"comparisons": [{"a": "destroyed", "b": true, "not_prev": true}], "value_to_change": "type", "diff": "empty", "push_front": true})
         add_effect({"comparisons": [{"a": "removed", "b": true, "not_prev": true}], "value_to_change": "type", "diff": "empty", "push_front": true})
-    else:
-        .add_conditional_effects()
-    
+        
     var patches := modloader.symbol_patches[self.type]
+    var override := false
     if patches != null:
         for patch in patches:
             if patch.has_method("add_conditional_effects"):
+                override = true
                 patch.add_conditional_effects(self, adj_icons)
+    if !override:
+        .add_conditional_effects()
     
     has_effects = true
 
@@ -222,8 +231,8 @@ func add_effect(effect):
         .add_effect(effect)
 
 func add_effect_to_symbol(y, x, effect):
+    self.texture_type = self.type
     if effect.effect_dictionary != null:
-        self.texture_type = self.type
         .add_effect_to_symbol(y, x, effect.effect_dictionary)
     else:
         .add_effect_to_symbol(y, x, effect)

--- a/luckyapi/modloader/utils.gd
+++ b/luckyapi/modloader/utils.gd
@@ -38,6 +38,38 @@ func join(a: String, b: String, delimeter := " ") -> String:
     
     return a + delimeter + b
 
+func nvl(a, b = 0, keep_falsy := true):
+    if keep_falsy:
+        if a in ["", 0, false, [], {}]:
+            return a
+    return a if a else b
+
+static func subtract(a: Array, b: Array) -> Array:
+    var result := []
+    var bag := {}
+    for item in b:
+        if not bag.has(item):
+            bag[item] = 0
+        bag[item] += 1
+    for item in a:
+        if bag.has(item):
+            bag[item] -= 1
+            if bag[item] == 0:
+                bag.erase(item)
+        else:
+            result.append(item)
+    return result
+
+
+static func merge(a: Array, b: Array) -> Array:
+    var result := a
+    if result.size() == 0:
+        return b
+    for item in b:
+        if not item in a:
+            result.push_back(item)
+    return result
+
 func splice(string, start, end, replace):
     return string.substr(0, start) + replace + string.substr(end)
 
@@ -46,13 +78,17 @@ func fix_translation(string):
 
 func fix_all_tags(string):
     var regex_all := RegEx.new()
-    regex_all.compile("<all_(and|or)_([a-zA-Z0-9_]+)>")
+    regex_all.compile("<all_(and|or|na)_([a-zA-Z0-9_]+)>")
     var result_all := regex_all.search(string)
     while result_all != null:
-        var join := result_all.get_string(1)
+        var join : String
+        if result_all.get_string(1) == "na":
+            join = ""
+        else:
+          join = result_all.get_string(1) + " "
         var id := result_all.get_string(2)
         var group_members := get_group_members(id)
-        var replace := "<group_" + id + "> " + join + " <last_" + id + ">"
+        var replace := "<group_" + id + "> " + join + "<last_" + id + ">"
         if group_members.size() == 0:
             replace = "none"
         if group_members.size() == 1:
@@ -117,14 +153,14 @@ func can_find_symbol(type):
 func get_symbol_groups(symbol_id: String):
     var groups := []
     for group_id in modloader.databases.group_database.symbols:
-        if modloader.databases.group_database.symbols[group_id].find(symbol_id) > -1:
+        if symbol_id in modloader.databases.group_database.symbols[group_id]:
             groups.push_back(group_id)
     
     return groups
 
 func get_symbol_rarity(symbol_id: String):
     for rarity in modloader.databases.rarity_database.symbols:
-        if modloader.databases.rarity_database.symbols[rarity].find(symbol_id) > -1:
+        if symbol_id in modloader.databases.rarity_database.symbols[rarity]:
             return rarity
     
     return null
@@ -759,6 +795,10 @@ class SymbolEffect:
         effect_dictionary.unconditional = true
         return self
     
+    func priority():
+        effect_dictionary.push_front = true
+        return self
+    
     func add_symbol_type(type: String):
         effect_dictionary.tiles_to_add.push_back({"type": type})
         return self
@@ -768,6 +808,16 @@ class SymbolEffect:
             effect_dictionary.tiles_to_add.push_back({"group": group, "min_rarity": min_rarity})
         else:
             effect_dictionary.tiles_to_add.push_back({"group": group})
+        return self
+    
+    func add_symbols_of_type(arr: Array):
+        for symbol in arr:
+            add_symbol_type(symbol)
+        return self
+    
+    func add_symbols_of_group(arr: Array, min_rarity := ""):
+        for group in arr:
+            add_symbol_group(group, min_rarity)
         return self
     
     func add_item_type(type: String):
@@ -872,6 +922,9 @@ class SymbolEffect:
     
     func add_permanent_bonus(diff: int):
         return self.add_to_value("permanent_bonus", diff)
+    
+    func multiply_permanent_multiplier(diff: int):
+        return self.multiply_value("permanent_multiplier", diff)
     
     func animate(animation: String, sfx_type := 0, targets := []):
         effect_dictionary.anim = animation


### PR DESCRIPTION
Major Changes:
- More utils functions
- Added clickable symbols! Create an "on_click()" function inside your ModSymbol to use (only try this if you know what you're doing)
- "<all_and|or" now has a third option "na" for if you want a list of icons without a logical operator
- Added the ability to bulk add symbols in an effect
- Added a function to change the permanent multiplier with an effect
- Added function to prioritize effects by pushing their execute order to the front of the queue (only try this if you know what you're doing)

Bug Fixes:
- Fixed issue where sfx weren't able to be patched onto symbols
- Fixed bug where chicken couldn't be patched
- Fixed bug related to multiple crashes involving items that checked symbol groups

Other:
- Removed absolute references where possible